### PR TITLE
MTP process some messages early Debug Stream

### DIFF
--- a/examples/SD_Program_MTP-logger/SD_Program_MTP-logger.ino
+++ b/examples/SD_Program_MTP-logger/SD_Program_MTP-logger.ino
@@ -52,22 +52,58 @@ static const uint32_t file_system_size = 1024 * 512;
 
 #define DBGSerial Serial
 
+// Quick and Dirty memory Stream...
+class RAMStream : public Stream {
+  public:
+  // overrides for Stream
+  virtual int available() {return (tail_ - head_); }
+  virtual int read() {return (tail_ != head_)? buffer_[head_++] : -1;  }
+  virtual int peek() {return (tail_ != head_)? buffer_[head_] : -1;  }
+
+  // overrides for Print
+  virtual size_t write(uint8_t b) {
+    if (tail_ < sizeof(buffer_)) {
+      buffer_[tail_++] = b;
+      return 1;
+    }
+    return 0;
+  }
+
+  enum {BUFFER_SIZE=32768};
+  uint8_t buffer_[BUFFER_SIZE];
+  uint32_t head_ = 0;
+  uint32_t tail_ = 0;
+};
+
 void setup()
 {
+  // setup to do quick and dirty ram stream until Serial or like is up...
+  RAMStream rstream;
+  // start up MTPD early which will if asked tell the MTP
+  // host that we are busy, until we have finished setting
+  // up...
+  DBGSerial.begin(2000000);
+  mtpd.PrintStream(&rstream);   // Setup which stream to use...
+
+  mtpd.begin();
 
   // Open serial communications and wait for port to open:
-  DBGSerial.begin(2000000);
   while (!DBGSerial && millis() < 5000) {
     // wait for serial port to connect.
   }
+  
+  // set to real stream
+  mtpd.PrintStream(&DBGSerial);   // Setup which stream to use...
+  int ch;
+  while ((ch = rstream.read()) != -1) DBGSerial.write(ch);
+
   if (CrashReport) {
     DBGSerial.print(CrashReport);
   }
   DBGSerial.println("\n" __FILE__ " " __DATE__ " " __TIME__);
 
-  DBGSerial.println("Initializing MTP Storage list ...");
+  DBGSerial.printf("%u Initializing MTP Storage list ...", millis());
 
-  mtpd.begin();
   DBGSerial.printf("Date: %u/%u/%u %u:%u:%u\n", day(), month(), year(),
                    hour(), minute(), second());
 
@@ -92,7 +128,7 @@ void setup()
     DBGSerial.printf("Set Storage Index drive to %u\n", istore);
   }
 
-  DBGSerial.println("SD initialized.");
+  DBGSerial.printf("%u SD initialized.\n", millis());
   menu();
 
 }

--- a/src/MTP.h
+++ b/src/MTP.h
@@ -58,10 +58,14 @@ public:
 
   explicit MTPD(MTPStorageInterface* storage): storage_(storage) {}
   int begin();
+
+  static inline Stream* PrintStream(void) {return printStream_;}
+  static void PrintStream(Stream *stream) {printStream_ = stream;}
   
 private:
   MTPStorageInterface* storage_;
-
+  static Stream *printStream_;
+   
   struct MTPHeader {
     uint32_t len;  // 0
     uint16_t type; // 4

--- a/src/SDMTPClass.h
+++ b/src/SDMTPClass.h
@@ -57,8 +57,10 @@ private:
   uint32_t store_;
 
   // Currently SDIO only, may add. SPI ones later
-  bool check_disk_insertion_ = false;
+  enum {LOOP_TASKS_NONE=0, LOOP_TASKS_CHECK_INSERT=0x01};
+  uint8_t loop_tasks_ = LOOP_TASKS_NONE;
   bool disk_valid_ = false;
+  uint32_t info_sector_free_clusters_ = 0;
   uint32_t disk_inserted_time_ = 0;
   enum {DISK_INSERT_TEST_TIME=2000};
 };

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -62,28 +62,9 @@ class mSD_Base
     mSD_Base() {
       fsCount = 0;
     }
-    uint32_t sd_addFilesystem(FS &fs, const char *name, MTPStorageInterfaceCB *callback, uint32_t user_token) {
-      if (fsCount < MTPD_MAX_FILESYSTEMS) {
-        sd_name[fsCount] = name;
-        sdx[fsCount] = &fs;
-        callbacks[fsCount] = callback;
-        user_tokens[fsCount] = user_token;
-        Serial.printf("sd_addFilesystem: %d %x %s %x %x\n", fsCount, (uint32_t)&fs, name, (uint32_t)callback, user_token);
-        return fsCount++;
-      }
-      return 0xFFFFFFFFUL;  // no room left
-    }
+    uint32_t sd_addFilesystem(FS &fs, const char *name, MTPStorageInterfaceCB *callback, uint32_t user_token);
 
-    bool sd_removeFilesystem(uint32_t store)
-    {
-      if ((store < (uint32_t)fsCount) && (sd_name[store])) {
-        sd_name[store] = nullptr;
-        sdx[store] = nullptr;
-        return true;
-      }
-      return false;;
-
-    }
+    bool sd_removeFilesystem(uint32_t store);
 
     uint32_t sd_getStoreID( const char *name)
     {


### PR DESCRIPTION
The mtpd.begin() now starts up interval timer that will go away the first time you call loop,  That allows it to process a few host messages quickly to hopefully not have the PC time out MTP while it is starting up.

With this also created quck and dirty memory stream, that can capture stuff before the USB Serial is ready.   Also added method to MTPD to set which stream output should go to and updated storage and some others to look at this.

Still WIP, some of this will likely be removed.